### PR TITLE
Add package.xml FreeCAD package metadata to support addon manager, various fixes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
++recursive-include freecad/cadquery2workbench/resources *
++recursive-include freecad/cadquery2workbench/templates *

--- a/freecad/cadquery2workbench/init_gui.py
+++ b/freecad/cadquery2workbench/init_gui.py
@@ -66,7 +66,14 @@ class CadQuery2_Workbench(Gui.Workbench):
         '''
         code which should be computed when this workbench is deactivated
         '''
-        pass
+        mw = Gui.getMainWindow()
+        dockWidgets = mw.findChildren(QDockWidget)
+        
+        for widget in dockWidgets:
+            if widget.objectName() == "Report view":
+                widget.setVisible(False)
+            elif widget.objectName() == "CadQuery Editor":
+                widget.setVisible(False)
 
 
 Gui.addWorkbench(CadQuery2_Workbench())

--- a/freecad/cadquery2workbench/script_commands.py
+++ b/freecad/cadquery2workbench/script_commands.py
@@ -506,7 +506,6 @@ class Script_Commands(QObject):
     def tofreecad(self, cqObject, feature):
         # Use a temporary BREP file to get the cadquery shape
         # Use FreeCAD Home directory
-        env = os.environ
         temppath = os.environ.get("FREECAD_USER_HOME", tempfile.mkdtemp())
         temppath += '/.FreeCAD/tmp'
         

--- a/freecad/cadquery2workbench/script_commands.py
+++ b/freecad/cadquery2workbench/script_commands.py
@@ -6,6 +6,7 @@ import os
 import pathlib
 import math as m
 from random import random
+import tempfile
 
 import FreeCAD as App
 import FreeCADGui as Gui
@@ -25,7 +26,7 @@ class Script_Commands(QObject):
         QObject.__init__(self, parent)
         self.parent = parent
         self.file_contents = None
-        self.previous_path = os.environ['HOME']
+        self.previous_path = os.environ.get("HOME", "")
         
         # QTimer to check if file was modified on the disk
         self.fiName = None
@@ -506,7 +507,7 @@ class Script_Commands(QObject):
         # Use a temporary BREP file to get the cadquery shape
         # Use FreeCAD Home directory
         env = os.environ
-        temppath = env['FREECAD_USER_HOME'] if 'FREECAD_USER_HOME' in env else env['HOME']
+        temppath = os.environ.get("FREECAD_USER_HOME", tempfile.mkdtemp())
         temppath += '/.FreeCAD/tmp'
         
         # if not exist create the tmp directory

--- a/package.xml
+++ b/package.xml
@@ -9,7 +9,7 @@
 
   <date>2024-11-01</date>
 
-  <maintainer>jpmlt</maintainer>
+  <maintainer email="jpm.gth@netc.fr">jpmlt</maintainer>
 
   <license file="LICENSE">Apache-2.0</license>
 

--- a/package.xml
+++ b/package.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <package format="1" xmlns="https://wiki.freecad.org/Package_Metadata">
 
-  <name>freecad cadquery</name>
+  <name>CadQuery2</name>
 
-  <description>cadquery2</description>
+  <description>This workbench integrates CadQuery into FreeCAD, enabling users to create parametric 3D models through script-based design directly within the FreeCAD environment.</description>
 
-  <version>2024.11.1</version>
+  <version>0.0.1</version>
 
   <date>2024-11-01</date>
 
-  <maintainer email="shaise@gmail.com">Shai Seger</maintainer>
+  <maintainer>jpmlt</maintainer>
 
-  <license file="LICENSE">GPL-2.0-or-later</license>
+  <license file="LICENSE">Apache-2.0</license>
 
-  <url branch="master" type="repository">https://github.com/mroote/freecad-cadquery2-workbench</url>
+  <url branch="master" type="repository">https://github.com/jpmlt/freecad-cadquery2-workbench</url>
 
-  <url type="readme">https://github.com/mroote/freecad-cadquery2-workbench/README.md</url>
+  <url type="readme">https://github.com/jpmlt/freecad-cadquery2-workbench/README.md</url>
 
   <icon>resources/CQ_Logo.svg</icon>
 

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<package format="1" xmlns="https://wiki.freecad.org/Package_Metadata">
+
+  <name>freecad cadquery</name>
+
+  <description>cadquery2</description>
+
+  <version>2024.11.1</version>
+
+  <date>2024-11-01</date>
+
+  <maintainer email="shaise@gmail.com">Shai Seger</maintainer>
+
+  <license file="LICENSE">GPL-2.0-or-later</license>
+
+  <url branch="master" type="repository">https://github.com/mroote/freecad-cadquery2-workbench</url>
+
+  <url type="readme">https://github.com/mroote/freecad-cadquery2-workbench/README.md</url>
+
+  <icon>resources/CQ_Logo.svg</icon>
+
+  <content>
+    <workbench>
+      <depend optional="False" type="python">cadquery</depend>
+      <tag>cadquery</tag>
+      <classname>CadQuery2_Workbench</classname>
+      <subdirectory>./</subdirectory>
+    </workbench>
+  </content>
+
+</package>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-cadquery

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+cadquery


### PR DESCRIPTION
Adds a package.xml file to support installation directly through the FreeCAD Addon Manager. 

**Note** The cadquery package will also have to be added in the FreeCAD-addons allowed dependencies file.

Also includes various small fixes:

- Fixed when user does not have a home dir env var available (Windows)
- Close text editor window when switching away from workbench
- Fixed #3 